### PR TITLE
Update README to add sourcing ROS

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,28 @@ This repository contains a docker setup for running [CS 4501 Robotics for Softwa
 You must have [Docker](https://www.docker.com/get-started) and [Docker Compose](https://docs.docker.com/compose/install/) installed.
 
 ## Quickstart
-- `git clone git@github.com:brian-yu/cs4501-robotics-docker.git`
-- `cd cs4501-robotics-docker`
-- `git clone https://github.com/less-lab-uva/CS4501-Labs.git`
-- `docker-compose up --build`
+- Clone this repo
+```
+git clone git@github.com:brian-yu/cs4501-robotics-docker.git
+cd cs4501-robotics-docker
+```
+- Clone the class repo, this will allow Docker to find it while running
+```
+git clone https://github.com/less-lab-uva/CS4501-Labs.git
+docker-compose up --build
+```
 - Go to http://localhost:8080/vnc.html in your browser
-- In a new terminal tab:
-  - `docker-compose exec ros bash`
-  - `cd CS4501-Labs/lab4_ws`
-  - `catkin build`
-  - `source devel/setup.bash`
-  - `roslaunch flightcontroller fly.launch`
-- In another terminal tab:
-  - `docker-compose exec ros bash`
-  - `cd CS4501-Labs/lab4_ws`
-  - `source devel/setup.bash`
-  - `rviz`
+- In a new terminal tab: `docker-compose exec ros bash`
+```
+cd CS4501-Labs/lab4_ws
+source /opt/ros/melodic/setup.bash
+catkin build
+source devel/setup.bash
+roslaunch flightcontroller fly.launch
+```
+- In another terminal tab: `docker-compose exec ros bash`
+```
+cd CS4501-Labs/lab4_ws
+source devel/setup.bash
+rviz
+```


### PR DESCRIPTION
I reformatted the README to make it easier to copy/paste. 

Also, in order to get `catkin build` to run I had to run `source /opt/ros/melodic/setup.bash`. Normally sourcing that file is added to `~/.bashrc` or similar so it happens on load, unsure what the easiest way to automate that within the docker framework is. Did you run into this issue?